### PR TITLE
(fix/pre-commit) Make Flake and Black 88 character

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,13 @@ repos:
     - id: black
       language: python
       types: [python]
-      args: ["--line-length=120"]
+      args: ["--line-length=88"]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:
     - id: flake8
+      args: ["--line-length=88"]
 
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: 5.0.4
     hooks:
     - id: flake8
-      args: ["--line-length=88"]
+      args: ["--max-line-length=88"]
 
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6


### PR DESCRIPTION
Make Flake and Black 88 character linewidth

## Purpose
This PR fixes the Flake and Black line width inconsistency to 88 characters.
This needs to be merged before #29 


 Closes #27 

Before this fix `Flake` and `Black` had inconsistent linewidth which caused an issue while pre-committing.


## Type of change

- Bugfix (non-breaking change which fixes an issue)



## Checklist
_Put an `x` in the boxes that apply._

- [x] My code functions as intended
- [x] I have addressed all the issues entirely
